### PR TITLE
Improve API route test coverage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi[all]
+fastapi[all]>=0.115
 uvicorn[standard]
 sqlmodel
 alembic
@@ -9,7 +9,7 @@ httpx
 python-multipart
 aiofiles
 pytest
-pydantic[all]
+pydantic[all]>=2
 python-jose
 passlib[bcrypt]
 pytest-asyncio

--- a/tests/auth/test_login.py
+++ b/tests/auth/test_login.py
@@ -16,3 +16,8 @@ async def test_login_and_protected(client, db):
     headers = {"Authorization": f"Bearer {token}"}
     r2 = await client.get("/personal/", headers=headers)
     assert r2.status_code == 200
+
+@pytest.mark.anyio
+async def test_login_invalid_credentials(client):
+    r = await client.post("/auth/login", json={"username": "wrong", "password": "bad"})
+    assert r.status_code == 401

--- a/tests/routes/test_archivos_routes.py
+++ b/tests/routes/test_archivos_routes.py
@@ -1,0 +1,46 @@
+import io
+import pytest
+from pathlib import Path
+from app.storage import local_repo
+
+
+@pytest.fixture
+def patch_upload_dir(tmp_path, monkeypatch):
+    upload_dir = tmp_path / "uploads"
+    upload_dir.mkdir()
+    monkeypatch.setattr(local_repo, "UPLOAD_DIR", str(upload_dir))
+
+    def noawait(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(local_repo, "eliminar", noawait)
+    return upload_dir
+
+
+@pytest.mark.anyio
+async def test_upload_list_download_delete_file(client, auth_headers, patch_upload_dir):
+    content = b"hello world"
+    files = {"file": ("hello.txt", io.BytesIO(content), "text/plain")}
+    resp = await client.post("/archivos/upload", files=files, headers=auth_headers)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "id" in data and data["ruta"]
+    file_id = data["id"]
+
+    # listing
+    resp = await client.get("/archivos/files/", headers=auth_headers)
+    assert resp.status_code == 200
+    assert any(item["id"] == file_id for item in resp.json())
+
+    # download
+    resp = await client.get(f"/archivos/download/{file_id}")
+    assert resp.status_code == 200
+    body = resp.content
+    assert body == content
+
+    # delete
+    resp = await client.delete(f"/archivos/files/{file_id}", headers=auth_headers)
+    assert resp.status_code == 200
+
+    resp = await client.get(f"/archivos/download/{file_id}")
+    assert resp.status_code == 404

--- a/tests/routes/test_proyectos_routes.py
+++ b/tests/routes/test_proyectos_routes.py
@@ -1,0 +1,51 @@
+import pytest
+from datetime import date, timedelta
+
+
+@pytest.mark.anyio
+async def test_proyecto_crud_flow(client, auth_headers):
+    data = {"nombre": "P1", "fecha_inicio": date.today().isoformat()}
+    r = await client.post("/proyectos/", json=data, headers=auth_headers)
+    assert r.status_code == 201
+    proyecto = r.json()
+    pid = proyecto["id"]
+
+    r = await client.get(f"/proyectos/{pid}")
+    assert r.status_code == 200
+
+    update_payload = {"nombre": "P1", "financiador": "ACME"}
+    r = await client.put(f"/proyectos/{pid}", json=update_payload, headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["financiador"] == "ACME"
+
+    r = await client.delete(f"/proyectos/{pid}", headers=auth_headers)
+    assert r.status_code == 200
+    r = await client.get(f"/proyectos/{pid}")
+    assert r.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_proyecto_fecha_invalida(client, auth_headers):
+    today = date.today()
+    data = {
+        "nombre": "BadDates",
+        "fecha_inicio": today.isoformat(),
+        "fecha_fin": (today - timedelta(days=1)).isoformat(),
+    }
+    r = await client.post("/proyectos/", json=data, headers=auth_headers)
+    assert r.status_code == 422
+
+@pytest.mark.anyio
+async def test_proyecto_asignar_personal(client, auth_headers):
+    # create personal
+    p_resp = await client.post("/personal/", json={"nombre": "Ana", "email": "ana@example.com"}, headers=auth_headers)
+    personal_id = p_resp.json()["id"]
+    # create proyecto
+    proj_resp = await client.post("/proyectos/", json={"nombre": "PP"}, headers=auth_headers)
+    proj_id = proj_resp.json()["id"]
+    # assign
+    items = [{"personal_id": personal_id, "rol": "Investigador"}]
+    resp = await client.post(f"/proyectos/{proj_id}/personal", json=items, headers=auth_headers)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data[0]["personal_id"] == personal_id

--- a/tests/routes/test_publicaciones_routes.py
+++ b/tests/routes/test_publicaciones_routes.py
@@ -1,0 +1,48 @@
+import pytest
+from datetime import date
+
+
+@pytest.mark.anyio
+async def test_publicacion_crud(client, auth_headers):
+    # crear autor
+    personal_data = {"nombre": "Autor", "email": "autor@example.com"}
+    r = await client.post("/personal/", json=personal_data, headers=auth_headers)
+    pid = r.json()["id"]
+
+    data = {
+        "titulo": "Investigation",
+        "anio": 2024,
+        "authors": [{"name": "Autor", "personal_id": pid}],
+    }
+    r = await client.post("/publicaciones/", json=data, headers=auth_headers)
+    assert r.status_code == 201
+    pub = r.json()
+    pub_id = pub["id"]
+
+    r = await client.get(f"/publicaciones/{pub_id}")
+    assert r.status_code == 200
+
+    r = await client.patch(
+        f"/publicaciones/{pub_id}", json={"estado": "Publicado"}, headers=auth_headers
+    )
+    assert r.status_code == 200
+    assert r.json()["estado"] == "Publicado"
+
+    r = await client.delete(f"/publicaciones/{pub_id}", headers=auth_headers)
+    assert r.status_code == 200
+    r = await client.get(f"/publicaciones/{pub_id}")
+    assert r.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_publicacion_autor_invalido(client, auth_headers):
+    data = {"titulo": "Bad", "anio": 2024, "authors": [{"name": "X", "personal_id": 9999}]}
+    r = await client.post("/publicaciones/", json=data, headers=auth_headers)
+    assert r.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_publicacion_anio_invalido(client, auth_headers):
+    data = {"titulo": "BadYear", "anio": 1800}
+    r = await client.post("/publicaciones/", json=data, headers=auth_headers)
+    assert r.status_code == 422

--- a/tests/routes/test_servicios_routes.py
+++ b/tests/routes/test_servicios_routes.py
@@ -1,0 +1,34 @@
+import pytest
+from datetime import date
+
+
+@pytest.mark.anyio
+async def test_servicio_crud(client, auth_headers):
+    # crear equipamiento
+    eq_resp = await client.post("/equipamiento/", json={"nombre": "EQ"}, headers=auth_headers)
+    eq_id = eq_resp.json()["id"]
+
+    data = {"nombre": "Serv", "tarifa": 10, "equipamiento_ids": [eq_id]}
+    r = await client.post("/servicios/", json=data, headers=auth_headers)
+    assert r.status_code == 201
+    sid = r.json()["id"]
+
+    r = await client.get(f"/servicios/{sid}")
+    assert r.status_code == 200
+
+    r = await client.patch(f"/servicios/{sid}", json={"tarifa": 20}, headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["tarifa"] == 20
+
+    r = await client.delete(f"/servicios/{sid}", headers=auth_headers)
+    assert r.status_code == 200
+
+    r = await client.get(f"/servicios/{sid}")
+    assert r.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_servicio_equipamiento_inexistente(client, auth_headers):
+    data = {"nombre": "Bad", "equipamiento_ids": [9999]}
+    r = await client.post("/servicios/", json=data, headers=auth_headers)
+    assert r.status_code == 404

--- a/tests/routes/test_subscriber_email.py
+++ b/tests/routes/test_subscriber_email.py
@@ -25,3 +25,10 @@ async def test_subscribe_and_notify(client, db, monkeypatch, auth_headers):
 
     assert "test@example.com" in sent
     assert sent["test@example.com"][0] == "Demo"
+
+@pytest.mark.anyio
+async def test_subscriber_duplicate_email(client):
+    r1 = await client.post("/suscriptores/", json={"email": "dup@example.com"})
+    assert r1.status_code == 201
+    r2 = await client.post("/suscriptores/", json={"email": "dup@example.com"})
+    assert r2.status_code == 409


### PR DESCRIPTION
## Summary
- add negative login test
- cover subscriber duplicate email path
- test file upload, listing, download and deletion
- exercise project, publication and service routes
- specify fastapi and pydantic versions for compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1cb5c730832b88666999134fe0f7